### PR TITLE
Include <limits> explicitly

### DIFF
--- a/open62541App/src/Open62541RecordAddress.h
+++ b/open62541App/src/Open62541RecordAddress.h
@@ -31,6 +31,7 @@
 #define OPEN62541_EPICS_RECORD_ADDRESS_H
 
 #include <cstdint>
+#include <limits>   // std::numeric_limits
 #include <string>
 
 extern "C" {


### PR DESCRIPTION
With GCC11 <limits> needs to be explicitly included to use `std::numeric_limits`

This will fix #6 